### PR TITLE
Implement predict & markets endpoints with UI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           ruff check src tests
           black --check src tests
           mypy src
+      - name: Ensure no ellipsis stubs
+        run: |
+          grep -R "\\.\\.\\." --include="*.py" . && exit 1 || true
       - name: Test
         run: pytest -q --disable-warnings
       - name: Coverage upload

--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,30 @@ __pycache__/
 .mypy_cache/
 .pytest_cache/
 .htmlcov/
+.ruff_cache/
 coverage.xml
-reports/
 logs/
 *.log
 .ipynb_checkpoints/
 .DS_Store
 .cache/
-data/raw/**/*.html
+
+# Generated datasets and reports
+data/**
+!data/.gitkeep
+!data/expectations/**
+!data/tests/**
+reports/**
+!reports/.gitkeep
+
+# Binary/model artifacts
 *.parquet
+*.pkl
+*.csv
+*.png
 *.db
+
 !.gitkeep
+
+# Project outputs
+notebooks/.ipynb_checkpoints/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: forbid-python-ellipsis
+        name: Prevent ellipsis stubs in Python
+        entry: bash -lc 'if git diff --cached --name-only | grep -E "\\.py$" | xargs -r grep -n "\\.\\.\\."; then echo "ERROR: stub ellipses found"; exit 1; fi'
+        language: system
+        pass_filenames: false
+        stages: [commit]

--- a/src/ufc_winprob/api/main.py
+++ b/src/ufc_winprob/api/main.py
@@ -1,51 +1,53 @@
-"""FastAPI application entrypoint."""
+"""FastAPI application entrypoint with observability instrumentation."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from time import perf_counter
-from typing import Any
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from ..logging import configure_logging
-from ..settings import get_settings
-from .routers import fights, markets, predict, probabilities, recommendations
-from .schemas import HealthResponse
-from ..observability import API_EXCEPTIONS, API_LATENCY, API_REQUESTS
+from ufc_winprob.api.routers import fights, markets, predict, probabilities, recommendations
+from ufc_winprob.api.schemas import HealthResponse
+from ufc_winprob.logging import configure_logging
+from ufc_winprob.observability import API_EXCEPTIONS, API_LATENCY, API_REQUESTS
+from ufc_winprob.settings import get_settings
+
+RequestHandler = Callable[[Request], Awaitable[Response]]
 
 
 class PrometheusRequestMiddleware(BaseHTTPMiddleware):
     """Collect Prometheus metrics for each API request."""
 
-    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+    async def dispatch(self, request: Request, call_next: RequestHandler) -> Response:  # type: ignore[override]
+        """Record metrics for a request lifecycle and propagate the response."""
         route = request.scope.get("route")
         route_path = getattr(route, "path", request.url.path)
         method = request.method
         start = perf_counter()
-        status_code = "500"
         try:
             response = await call_next(request)
         except Exception:
             API_EXCEPTIONS.labels(route=route_path, method=method).inc()
+            API_REQUESTS.labels(route=route_path, method=method, status="500").inc()
+            API_LATENCY.labels(route=route_path, method=method).observe(perf_counter() - start)
             raise
-        else:
-            status_code = str(response.status_code)
-            return response
-        finally:
-            duration = perf_counter() - start
-            API_REQUESTS.labels(route=route_path, method=method, status=status_code).inc()
-            API_LATENCY.labels(route=route_path, method=method).observe(duration)
+        status_code = str(response.status_code)
+        API_REQUESTS.labels(route=route_path, method=method, status=status_code).inc()
+        API_LATENCY.labels(route=route_path, method=method).observe(perf_counter() - start)
+        return response
 
 
 def create_app() -> FastAPI:
+    """Instantiate the FastAPI application."""
     settings = get_settings()
     configure_logging()
-    app = FastAPI(title=settings.project_name)
 
+    app = FastAPI(title=settings.project_name)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -56,11 +58,12 @@ def create_app() -> FastAPI:
 
     @app.get("/health", response_model=HealthResponse, tags=["system"])
     def health() -> HealthResponse:
-        return HealthResponse(status="ok", timestamp=datetime.now(timezone.utc))
+        return HealthResponse(status="ok", timestamp=datetime.now(UTC))
 
     @app.get("/metrics", tags=["system"])
     def metrics() -> Response:
-        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+        payload = generate_latest()
+        return Response(payload, media_type=CONTENT_TYPE_LATEST)
 
     app.include_router(fights.router)
     app.include_router(probabilities.router)
@@ -72,10 +75,11 @@ def create_app() -> FastAPI:
 
 
 def main() -> None:
+    """Run the development server."""
     import uvicorn
 
     app = create_app()
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # noqa: S104
 
 
 if __name__ == "__main__":

--- a/src/ufc_winprob/api/routers/markets.py
+++ b/src/ufc_winprob/api/routers/markets.py
@@ -2,40 +2,82 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import List
 
-from fastapi import APIRouter
 import pandas as pd
+from fastapi import APIRouter
 
-from ..schemas import MarketResponse
+from ufc_winprob.api.schemas import MarketResponse
 
 router = APIRouter(prefix="/markets", tags=["markets"])
 
+_DATA_PATH = Path("data/processed/market_odds.parquet")
 
-@router.get("/", response_model=List[MarketResponse])
-def markets() -> List[MarketResponse]:
-    path = Path("data/processed/market_odds.parquet")
-    if not path.exists():
+
+def _ensure_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Ensure the DataFrame contains the columns required by the API schema."""
+    working = frame.copy()
+    if "timestamp" not in working.columns:
+        working["timestamp"] = datetime.now(UTC)
+    working["timestamp"] = pd.to_datetime(working["timestamp"], utc=True)
+
+    if "american_odds" not in working.columns:
+        working["american_odds"] = 0.0
+    if "implied_probability" not in working.columns:
+        working["implied_probability"] = 0.5
+    if "normalized_probability" not in working.columns:
+        working["normalized_probability"] = working["implied_probability"].astype(float)
+    if "overround" not in working.columns:
+        working["overround"] = 0.0
+    if "z_shin" not in working.columns:
+        working["z_shin"] = 0.0
+    if "stale" not in working.columns:
+        working["stale"] = False
+    if "book" not in working.columns:
+        working["book"] = working.get("sportsbook", "Unknown")
+    if "sportsbook" not in working.columns:
+        working["sportsbook"] = working["book"]
+    return working
+
+
+@router.get("/", response_model=list[MarketResponse])
+def markets() -> list[MarketResponse]:
+    """Return the latest market snapshot for each recorded bout."""
+    if not _DATA_PATH.exists():
         return []
-    frame = pd.read_parquet(path)
-    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
-    responses: List[MarketResponse] = []
-    has_book = "book" in frame.columns
-    for row in frame.itertuples(index=False):
-        book_value = str(getattr(row, "book")) if has_book else str(row.sportsbook)
+
+    frame = pd.read_parquet(_DATA_PATH)
+    if frame.empty:
+        return []
+
+    normalized = _ensure_columns(frame)
+    responses: list[MarketResponse] = []
+    for row in normalized.itertuples(index=False):
+        timestamp = row.timestamp
+        if isinstance(timestamp, str):
+            ts = datetime.fromisoformat(timestamp)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+        else:
+            ts = timestamp.to_pydatetime() if hasattr(timestamp, "to_pydatetime") else timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            else:
+                ts = ts.astimezone(UTC)
+
         responses.append(
             MarketResponse(
-                bout_id=str(row.bout_id),
-                book=book_value,
-                sportsbook=str(row.sportsbook),
-                price=float(row.american_odds),
-                implied_probability=float(row.implied_probability),
-                normalized_probability=float(row.normalized_probability),
-                overround=float(row.overround),
-                last_updated=row.timestamp.to_pydatetime(),
-                z_shin=float(row.z_shin) if "z_shin" in frame.columns else 0.0,
-                stale=bool(row.stale) if "stale" in frame.columns else False,
+                bout_id=str(getattr(row, "bout_id", "")),
+                book=str(getattr(row, "book", getattr(row, "sportsbook", "Unknown"))),
+                sportsbook=str(getattr(row, "sportsbook", getattr(row, "book", "Unknown"))),
+                price=float(getattr(row, "american_odds", 0.0)),
+                implied_probability=float(getattr(row, "implied_probability", 0.5)),
+                normalized_probability=float(getattr(row, "normalized_probability", 0.5)),
+                overround=float(getattr(row, "overround", 0.0)),
+                last_updated=ts,
+                z_shin=float(getattr(row, "z_shin", 0.0)),
+                stale=bool(getattr(row, "stale", False)),
             )
         )
     return responses

--- a/src/ufc_winprob/api/routers/predict.py
+++ b/src/ufc_winprob/api/routers/predict.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+import numpy as np
 import pandas as pd
 from fastapi import APIRouter, HTTPException
 
@@ -13,87 +16,128 @@ from ufc_winprob.utils.odds_utils import american_to_implied
 
 router = APIRouter(tags=["probabilities"])
 
+_DEFAULT_RATING = 1500.0
+_DEFAULT_HEIGHT = 72.0
+_DEFAULT_REACH = 72.0
+_DEFAULT_AGE = 30.0
+_DEFAULT_ACTIVITY_GAP = 60.0
+_DEFAULT_DIVISION = "LW"
 
-def _base_feature_vector(feature_names: pd.Index) -> dict[str, float]:
-    """Construct a neutral feature vector compatible with the trained model."""
-    base: dict[str, float] = dict.fromkeys(feature_names, 0.0)
+
+def _neutral_feature_vector(feature_names: Iterable[str]) -> dict[str, float]:
+    """Return a neutral feature dictionary compatible with the trained model."""
+    features: dict[str, float] = {}
     for name in feature_names:
         if name.startswith("fighter_") or name.startswith("opponent_"):
-            base[name] = 1500.0
+            features[name] = _DEFAULT_RATING
         elif name == "scheduled_rounds":
-            base[name] = 3.0
+            features[name] = 3.0
         elif name == "is_main_event":
-            base[name] = 0.0
+            features[name] = 0.0
         elif name == "activity_gap":
-            base[name] = 60.0
+            features[name] = _DEFAULT_ACTIVITY_GAP
         elif name == "market_prob":
-            base[name] = 0.5
-    return base
+            features[name] = 0.5
+        elif name.endswith("_diff"):
+            features[name] = 0.0
+        else:
+            features[name] = 0.0
+    return features
+
+
+def _apply_metric_features(
+    features: dict[str, float],
+    fighter_value: float,
+    opponent_value: float,
+    prefix: str,
+) -> None:
+    """Populate mirrored features and their difference when available."""
+    primary = f"{prefix}_a"
+    secondary = f"{prefix}_b"
+    diff_name = f"{prefix}_diff"
+    if primary in features:
+        features[primary] = fighter_value
+    if secondary in features:
+        features[secondary] = opponent_value
+    if diff_name in features:
+        features[diff_name] = fighter_value - opponent_value
 
 
 def _build_feature_frame(
-    payload: PredictRequest, feature_names: pd.Index, market_prob: float
+    payload: PredictRequest,
+    feature_index: pd.Index,
+    market_probability: float,
+    division: str,
 ) -> pd.DataFrame:
-    """Populate a single-row feature frame for inference."""
-    features = _base_feature_vector(feature_names)
-    fighter_age = payload.fighter_age or 30.0
-    opponent_age = payload.opponent_age or 30.0
-    fighter_height = payload.fighter_height or 72.0
-    opponent_height = payload.opponent_height or 72.0
-    fighter_reach = payload.fighter_reach or 72.0
-    opponent_reach = payload.opponent_reach or 72.0
+    """Construct the single-row feature frame expected by the classifier."""
+    features = _neutral_feature_vector(feature_index)
+    fighter_age = float(payload.fighter_age or _DEFAULT_AGE)
+    opponent_age = float(payload.opponent_age or _DEFAULT_AGE)
+    fighter_height = float(payload.fighter_height or _DEFAULT_HEIGHT)
+    opponent_height = float(payload.opponent_height or _DEFAULT_HEIGHT)
+    fighter_reach = float(payload.fighter_reach or _DEFAULT_REACH)
+    opponent_reach = float(payload.opponent_reach or _DEFAULT_REACH)
 
-    def assign(name: str, value: float) -> None:
-        if name in features:
-            features[name] = float(value)
+    _apply_metric_features(features, fighter_age, opponent_age, "age")
+    _apply_metric_features(features, fighter_height, opponent_height, "height")
+    _apply_metric_features(features, fighter_reach, opponent_reach, "reach")
 
-    assign("age_a", fighter_age)
-    assign("age_b", opponent_age)
-    assign("age_diff", fighter_age - opponent_age)
-    assign("age_effect_a", age_curve_effect(fighter_age, "LW"))
-    assign("age_effect_b", age_curve_effect(opponent_age, "LW"))
-    assign("height_a", fighter_height)
-    assign("height_b", opponent_height)
-    assign("height_diff", fighter_height - opponent_height)
-    assign("reach_a", fighter_reach)
-    assign("reach_b", opponent_reach)
-    assign("reach_diff", fighter_reach - opponent_reach)
-    assign("market_prob", market_prob)
+    age_effect_a = age_curve_effect(fighter_age, division)
+    age_effect_b = age_curve_effect(opponent_age, division)
+    if "age_effect_a" in features:
+        features["age_effect_a"] = age_effect_a
+    if "age_effect_b" in features:
+        features["age_effect_b"] = age_effect_b
+    if "age_effect_diff" in features:
+        features["age_effect_diff"] = age_effect_a - age_effect_b
 
-    return pd.DataFrame([features], columns=feature_names)
+    if "market_prob" in features:
+        features["market_prob"] = market_probability
+
+    frame = pd.DataFrame([features], columns=feature_index)
+    return frame.astype(np.float64, copy=False)
+
+
+def _load_model_artifacts() -> tuple[object, Calibrator]:
+    try:
+        classifier = load_artifact("classifier.joblib")
+        calibrator = Calibrator.load(MODEL_DIR / "calibrator.joblib")
+    except FileNotFoundError as exc:  # pragma: no cover - validated in tests
+        raise HTTPException(status_code=503, detail="Model artifacts unavailable") from exc
+    return classifier, calibrator
 
 
 @router.post("/predict", response_model=PredictionResponse)
 def predict_single(payload: PredictRequest) -> PredictionResponse:
-    market_probability = None
-    if payload.american_odds is not None:
+    """Generate a win probability for the requested fighter."""
+    american_odds = payload.american_odds
+    market_probability: float | None = None
+    if american_odds is not None:
         try:
-            market_probability = american_to_implied(payload.american_odds)
-        except ValueError:
-            market_probability = None
+            market_probability = american_to_implied(american_odds)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    try:
-        classifier = load_artifact("classifier.joblib")
-        calibrator = Calibrator.load(MODEL_DIR / "calibrator.joblib")
-    except FileNotFoundError as exc:  # pragma: no cover - guarded by tests
-        raise HTTPException(status_code=503, detail="Model artifacts unavailable") from exc
+    classifier, calibrator = _load_model_artifacts()
 
     feature_names = getattr(classifier, "feature_names_in_", None)
     if feature_names is None:
-        raise HTTPException(status_code=500, detail="Model is missing feature metadata")
+        raise HTTPException(status_code=500, detail="Model missing feature metadata")
 
+    division = (payload.division or calibrator.default_division or _DEFAULT_DIVISION).upper()
     base_prob = market_probability if market_probability is not None else 0.5
     feature_index = pd.Index(feature_names)
-    frame = _build_feature_frame(payload, feature_index, base_prob)
+    frame = _build_feature_frame(payload, feature_index, base_prob, division)
 
     try:
-        raw_score = float(classifier.predict_proba(frame)[0, 1])
+        probabilities = classifier.predict_proba(frame)
     except Exception as exc:  # pragma: no cover - defensive guard
         raise HTTPException(status_code=500, detail="Model inference failed") from exc
 
-    calibrated = float(calibrator.transform([raw_score], ["GLOBAL"])[0])
-    probability_low = max(calibrated - 0.05, 0.0)
-    probability_high = min(calibrated + 0.05, 1.0)
+    raw_probability = float(probabilities[0, 1])
+    calibrated = float(calibrator.transform([raw_probability], [division])[0])
+    probability_low = float(np.clip(calibrated - 0.05, 0.0, 1.0))
+    probability_high = float(np.clip(calibrated + 0.05, 0.0, 1.0))
 
     return PredictionResponse(
         bout_id=payload.bout_id,

--- a/src/ufc_winprob/api/schemas.py
+++ b/src/ufc_winprob/api/schemas.py
@@ -50,6 +50,7 @@ class PredictRequest(BaseModel):
     bout_id: str
     fighter: str
     opponent: str
+    division: Optional[str] = None
     american_odds: Optional[float] = None
     fighter_age: Optional[float] = None
     opponent_age: Optional[float] = None

--- a/src/ufc_winprob/ui/app.py
+++ b/src/ufc_winprob/ui/app.py
@@ -4,110 +4,146 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterable
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import streamlit as st
 
-from ..models.backtest import BACKTEST_PATH, BACKTEST_REPORT_PATH
-from ..models.predict import PREDICTIONS_PATH
-from ..pipelines.update_upcoming import run as update_upcoming
-from ..settings import get_settings
-from .plots import calibration_plot
+from ufc_winprob.models.backtest import BACKTEST_PATH, BACKTEST_REPORT_PATH
+from ufc_winprob.models.predict import PREDICTIONS_PATH
+from ufc_winprob.pipelines.update_upcoming import run as update_upcoming
+from ufc_winprob.settings import get_settings
 
 st.set_page_config(page_title="UFC Win Probabilities", layout="wide")
 
 ASSETS_DIR = Path(__file__).parent / "assets"
 MARKET_PATH = Path("data/processed/market_odds.parquet")
-LEADERBOARD_PATH = Path("data/processed/ev_leaderboard.csv")
-PLOTS_DIR = Path("data/processed/plots")
+LEADERBOARD_PATH = Path("reports/ev_leaderboard.csv")
+PROCESSED_LEADERBOARD_PATH = Path("data/processed/ev_leaderboard.csv")
+CALIBRATION_METRICS_PATH = Path("data/processed/metrics_by_division.csv")
+CALIBRATION_PLOTS_DIR = Path("data/processed/plots")
 
 
 def _inject_styles() -> None:
+    """Inject optional CSS overrides into the Streamlit app."""
     css_path = ASSETS_DIR / "styles.css"
     if css_path.exists():
-        st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
+        st.markdown(
+            f"<style>{css_path.read_text(encoding='utf-8')}</style>",
+            unsafe_allow_html=True,
+        )
+
+
+def _load_parquet(path: Path) -> pd.DataFrame:
+    if path.exists():
+        return pd.read_parquet(path)
+    return pd.DataFrame()
 
 
 def load_predictions() -> pd.DataFrame:
-    if PREDICTIONS_PATH.exists():
-        return pd.read_parquet(PREDICTIONS_PATH)
-    update_upcoming()
+    """Load cached predictions if present."""
     if PREDICTIONS_PATH.exists():
         return pd.read_parquet(PREDICTIONS_PATH)
     return pd.DataFrame()
 
 
 def load_leaderboard() -> pd.DataFrame:
+    """Load the EV leaderboard from either reports or processed data."""
     if LEADERBOARD_PATH.exists():
         return pd.read_csv(LEADERBOARD_PATH)
+    if PROCESSED_LEADERBOARD_PATH.exists():
+        return pd.read_csv(PROCESSED_LEADERBOARD_PATH)
     return pd.DataFrame()
 
 
 def load_market_data() -> pd.DataFrame:
-    if MARKET_PATH.exists():
-        frame = pd.read_parquet(MARKET_PATH)
+    """Load the latest market snapshot."""
+    frame = _load_parquet(MARKET_PATH)
+    if not frame.empty and "timestamp" in frame.columns:
         frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
-        return frame
+    return frame
+
+
+def load_calibration_metrics() -> pd.DataFrame:
+    """Load per-division calibration metrics if generated."""
+    if CALIBRATION_METRICS_PATH.exists():
+        return pd.read_csv(CALIBRATION_METRICS_PATH)
     return pd.DataFrame()
 
 
+def _display_backtest_summary() -> None:
+    """Render the backtest report if it has been produced."""
+    st.subheader("Backtest Summary")
+    report_path = BACKTEST_REPORT_PATH if BACKTEST_REPORT_PATH.exists() else BACKTEST_PATH
+    if report_path.exists():
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        st.json(payload)
+    else:
+        st.info("Backtest report not available. Run `make refresh` to generate it.")
+
+
 def render_overview(predictions: pd.DataFrame, leaderboard: pd.DataFrame) -> None:
+    """Render the overview dashboard combining probabilities and reports."""
     st.subheader("Upcoming Probabilities")
     if predictions.empty:
-        st.info("No predictions available. Run a refresh to generate them.")
+        st.info("No predictions available. Use the refresh controls to generate data.")
     else:
-        display_cols = [col for col in predictions.columns if "fighter" in col or "prob" in col]
-        st.dataframe(predictions[display_cols])
+        display_cols = [
+            col
+            for col in predictions.columns
+            if any(keyword in col for keyword in ("bout", "fighter", "probability"))
+        ]
+        st.dataframe(predictions[display_cols], use_container_width=True)
 
     st.subheader("EV Leaderboard")
     if leaderboard.empty:
-        st.info("Run the refresh pipeline to compute EV leaderboard results.")
+        st.info("No EV leaderboard found. Run `make refresh` to publish reports.")
     else:
-        st.dataframe(leaderboard)
+        st.dataframe(leaderboard, use_container_width=True)
 
-    st.subheader("Calibration Snapshot")
-    if predictions.empty:
-        st.info("Predictions required to render calibration chart.")
-    else:
-        outcomes = np.random.binomial(1, predictions["probability"])
-        buffer = calibration_plot(predictions["probability"], outcomes)
-        st.image(buffer)
+    _display_backtest_summary()
 
-    st.subheader("Backtest Summary")
-    backtest_path = BACKTEST_REPORT_PATH if BACKTEST_REPORT_PATH.exists() else BACKTEST_PATH
-    if backtest_path.exists():
-        st.json(json.loads(backtest_path.read_text()))
-    else:
-        st.info("Run the daily refresh to generate backtest metrics.")
+
+def _extract_events(frame: pd.DataFrame) -> pd.DataFrame:
+    working = frame.copy()
+    if "event_id" not in working.columns:
+        working["event_id"] = working["bout_id"].str.split("-", n=1).str[0]
+    return working
+
+
+def _pivot_probabilities(frame: pd.DataFrame) -> pd.DataFrame:
+    pivot = frame.pivot_table(
+        index="timestamp",
+        columns="sportsbook",
+        values="implied_probability",
+        aggfunc="last",
+    ).sort_index()
+    return pivot
 
 
 def render_line_movement(market_data: pd.DataFrame) -> None:
+    """Visualize line movement for the selected event and bout."""
     st.subheader("Line Movement")
     if market_data.empty:
-        st.info("No market data available yet. Trigger a refresh to pull odds.")
+        st.info("No market data is available yet. Trigger a refresh to pull odds.")
         return
 
-    market_data = market_data.sort_values("timestamp")
-    if "event_id" not in market_data.columns:
-        market_data["event_id"] = market_data["bout_id"].str.split("-", n=1).str[0]
-
-    event_options = market_data["event_id"].dropna().unique().tolist()
-    if not event_options:
-        st.info("No events available in the current market snapshot.")
+    market_data = _extract_events(market_data)
+    event_ids = market_data["event_id"].dropna().unique().tolist()
+    if not event_ids:
+        st.info("No events found in the current odds snapshot.")
         return
 
-    selected_event = st.selectbox("Select event", event_options)
+    selected_event = st.selectbox("Select event", event_ids)
     event_frame = market_data[market_data["event_id"] == selected_event]
-    bout_options = event_frame["bout_id"].unique().tolist()
-    if not bout_options:
-        st.info("No bouts available for the selected event.")
+    bout_ids = event_frame["bout_id"].unique().tolist()
+    if not bout_ids:
+        st.info("No bouts found for the selected event.")
         return
 
-    selected_bout = st.selectbox("Select bout", bout_options)
-    bout_frame = event_frame[event_frame["bout_id"] == selected_bout]
-
+    selected_bout = st.selectbox("Select bout", bout_ids)
+    bout_frame = event_frame[event_frame["bout_id"] == selected_bout].sort_values("timestamp")
     summary = (
         bout_frame.groupby("sportsbook")
         .agg(
@@ -119,63 +155,87 @@ def render_line_movement(market_data: pd.DataFrame) -> None:
     )
     summary["delta"] = summary["current_probability"] - summary["open_probability"]
     summary = summary.sort_values("current_probability", ascending=False)
+
+    st.markdown("### Sportsbook Snapshot")
     st.dataframe(
         summary[["sportsbook", "open_probability", "current_probability", "delta", "last_updated"]],
         use_container_width=True,
     )
 
-    movement_chart = bout_frame.pivot_table(
-        index="timestamp",
-        columns="sportsbook",
-        values="implied_probability",
-        aggfunc="last",
-    )
-    if movement_chart.empty:
-        st.info("Line history not available yet for the selected bout.")
+    st.markdown("### Probability History")
+    history = _pivot_probabilities(bout_frame)
+    if history.empty or history.shape[0] < 2:
+        st.info("Historical line movement is unavailable for this bout yet.")
     else:
-        st.line_chart(movement_chart)
+        st.line_chart(history, use_container_width=True)
 
 
-def render_calibration() -> None:
+def _chunked(iterable: Iterable[Path], size: int) -> list[list[Path]]:
+    """Split an iterable of paths into rows for display."""
+    chunk: list[Path] = []
+    grid: list[list[Path]] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == size:
+            grid.append(chunk)
+            chunk = []
+    if chunk:
+        grid.append(chunk)
+    return grid
+
+
+def render_calibration(metrics: pd.DataFrame) -> None:
+    """Render calibration metrics table and associated plots."""
     st.subheader("Division Calibration Metrics")
-    metrics_path = Path("data/processed/metrics_by_division.csv")
-    if metrics_path.exists():
-        metrics = pd.read_csv(metrics_path)
-        st.dataframe(metrics)
-    else:
+    if metrics.empty:
         st.info("Calibration metrics not found. Run `make train` to generate them.")
+    else:
+        metrics_display = metrics.sort_values("ece")
+        st.dataframe(metrics_display, use_container_width=True)
 
     st.subheader("Reliability Plots")
-    plots = sorted(PLOTS_DIR.glob("*.png"))
-    if not plots:
-        st.info("No reliability plots available. Run `make train` to create calibration visuals.")
-    else:
-        for image in plots:
-            st.image(str(image), caption=image.stem.replace("_", " ").title())
+    plot_paths = sorted(CALIBRATION_PLOTS_DIR.glob("calibration_*.png"))
+    if not plot_paths:
+        st.info("Calibration plots missing. Run `make train` to create reliability visuals.")
+        return
+
+    for row in _chunked(plot_paths, size=2):
+        columns = st.columns(len(row))
+        for col, image_path in zip(columns, row, strict=False):
+            col.image(str(image_path), caption=image_path.stem.replace("_", " ").title())
+
+
+def _refresh_data(use_live_odds: bool) -> None:
+    """Trigger the upcoming pipeline with the requested odds source."""
+    update_upcoming(use_live_odds=use_live_odds)
 
 
 def main() -> None:
+    """Entrypoint for the Streamlit dashboard."""
     _inject_styles()
     st.title("UFC Win Probability Platform")
+
     settings = get_settings()
-    live_available = bool(settings.odds_api_key or os.getenv("ODDS_API_KEY"))
+    odds_key = os.getenv("ODDS_API_KEY") or settings.odds_api_key
+    live_available = bool(odds_key)
 
     st.sidebar.header("Controls")
-    use_live_default = settings.use_live_odds if live_available else False
     if "use_live_odds" not in st.session_state:
-        st.session_state["use_live_odds"] = use_live_default
+        st.session_state["use_live_odds"] = bool(live_available and settings.use_live_odds)
+
     toggle_value = st.sidebar.toggle(
         "Use live odds",
         value=st.session_state["use_live_odds"],
         disabled=not live_available,
-        help="Requires ODDS_API_KEY to be configured.",
+        help="Requires ODDS_API_KEY to be configured in the environment.",
     )
     if toggle_value != st.session_state["use_live_odds"]:
         st.session_state["use_live_odds"] = toggle_value
-        update_upcoming(use_live_odds=toggle_value and live_available)
+        _refresh_data(use_live_odds=toggle_value)
         st.experimental_rerun()
+
     if st.sidebar.button("Refresh Data"):
-        update_upcoming(use_live_odds=st.session_state["use_live_odds"] and live_available)
+        _refresh_data(use_live_odds=st.session_state["use_live_odds"])
         st.experimental_rerun()
 
     page = st.sidebar.radio("Page", ("Overview", "Line Movement", "Calibration"))
@@ -183,13 +243,14 @@ def main() -> None:
     predictions = load_predictions()
     leaderboard = load_leaderboard()
     market_data = load_market_data()
+    calibration_metrics = load_calibration_metrics()
 
     if page == "Overview":
         render_overview(predictions, leaderboard)
     elif page == "Line Movement":
         render_line_movement(market_data)
     else:
-        render_calibration()
+        render_calibration(calibration_metrics)
 
 
 if __name__ == "__main__":

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,16 +1,19 @@
+"""API contract tests for core endpoints."""
+
 from __future__ import annotations
 
+# ruff: noqa: S101
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pandas as pd
 from fastapi.testclient import TestClient
 
+from ufc_winprob.api.main import create_app
 from ufc_winprob.api.schemas import PredictionResponse
 
-from ufc_winprob.api.main import create_app
 
-
-def _prepare_market_fixture() -> None:
+def _prepare_market_fixture() -> Path:
     path = Path("data/processed/market_odds.parquet")
     path.parent.mkdir(parents=True, exist_ok=True)
     frame = pd.DataFrame(
@@ -18,27 +21,26 @@ def _prepare_market_fixture() -> None:
             {
                 "bout_id": "evt-1-main",
                 "sportsbook": "MockBook",
+                "book": "MockBook",
                 "american_odds": -120,
                 "implied_probability": 0.55,
                 "normalized_probability": 0.52,
-                "shin_probability": 0.51,
-                "z_shin": 0.1,
                 "overround": 0.04,
-                "timestamp": "2024-01-01T12:00:00+00:00",
+                "z_shin": 0.1,
+                "timestamp": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
                 "stale": False,
-                "implied_rank": 1,
-                "normalized_rank": 1,
-                "shin_rank": 1,
             }
         ]
     )
     frame.to_parquet(path, index=False)
+    return path
 
 
 def test_markets_returns_all_fields() -> None:
     _prepare_market_fixture()
     app = create_app()
     client = TestClient(app)
+
     response = client.get("/markets/")
     assert response.status_code == 200
     payload = response.json()
@@ -73,8 +75,10 @@ def test_markets_returns_all_fields() -> None:
 def test_predict_validation_errors() -> None:
     app = create_app()
     client = TestClient(app)
+
     response = client.post("/predict", json={"fighter": "Name"})
     assert response.status_code == 422
+
     response = client.post(
         "/predict",
         json={"bout_id": "evt", "fighter": "Name", "opponent": 123},
@@ -82,13 +86,14 @@ def test_predict_validation_errors() -> None:
     assert response.status_code == 422
 
 
-def test_predict_endpoint_returns_response_schema(trained_model) -> None:
+def test_predict_endpoint_returns_response_schema(trained_model: dict[str, Path]) -> None:
     app = create_app()
     client = TestClient(app)
     payload = {
         "bout_id": "evt-1-main",
         "fighter": "Fighter A",
         "opponent": "Fighter B",
+        "division": "LW",
         "american_odds": -135,
         "fighter_age": 32,
         "opponent_age": 29,
@@ -97,6 +102,7 @@ def test_predict_endpoint_returns_response_schema(trained_model) -> None:
         "fighter_reach": 74,
         "opponent_reach": 70,
     }
+
     response = client.post("/predict", json=payload)
     assert response.status_code == 200
     data = response.json()
@@ -107,3 +113,21 @@ def test_predict_endpoint_returns_response_schema(trained_model) -> None:
     assert 0.0 <= data["probability"] <= 1.0
     assert data["probability_low"] <= data["probability"] <= data["probability_high"]
     assert data["market_probability"] is not None
+
+
+def test_metrics_endpoint_exposes_counters() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    health = client.get("/health")
+    assert health.status_code == 200
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    body = metrics.text
+    for metric_name in (
+        "ufc_api_requests_total",
+        "ufc_api_request_latency_seconds",
+        "ufc_api_exceptions_total",
+    ):
+        assert metric_name in body


### PR DESCRIPTION
## Summary
- rebuild the `/predict` handler to construct neutral feature vectors, apply age curve effects by division, and calibrate model output from persisted artifacts
- ensure the markets router loads parquet odds data with guaranteed fields, UTC timestamps, and schema defaults
- wire comprehensive Prometheus metrics middleware and expose `/metrics`, while extending UI pages for line movement, calibration assets, and live-odds refresh flow
- add API contract tests for predict/markets/metrics plus a Great Expectations CLI failure guard, and enforce hygiene via `.gitignore`, pre-commit, and CI ellipsis check

## Testing
- `pytest tests/test_api_contract.py tests/test_data_quality.py` *(fails: pandas module not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58e0e06e48320b75c7b6d23024fad