### PR TITLE
Add calibration metric utilities and tests

### DIFF
--- a/src/ufc_winprob/utils/metrics.py
+++ b/src/ufc_winprob/utils/metrics.py
@@ -1,82 +1,154 @@
-"""Metrics utilities for calibration and ROI evaluation."""
+"""Utility functions for evaluating probabilistic forecasts and betting returns."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Tuple
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 
 @dataclass(frozen=True)
 class MetricResult:
-    """Container for metric values with optional confidence interval."""
+    """Container for a metric value with optional confidence intervals."""
 
     value: float
     lower: float | None = None
     upper: float | None = None
 
 
-def brier_score(y_true: Iterable[int], y_prob: Iterable[float]) -> float:
-    true = np.asarray(list(y_true), dtype=float)
-    prob = np.asarray(list(y_prob), dtype=float)
+def _to_1d_float(array: ArrayLike) -> np.ndarray:
+    """Convert an arbitrary array-like structure to a one-dimensional float array."""
+    arr = np.asarray(array, dtype=float)
+    if arr.ndim == 0:
+        return arr.reshape(1)
+    return arr.reshape(-1)
+
+
+def _validate_binary(name: str, array: np.ndarray) -> None:
+    """Ensure that an array only contains binary outcomes (0 or 1)."""
+    if np.any((array < 0.0) | (array > 1.0)):
+        raise ValueError(f"{name} must only contain values in [0, 1].")
+    unique_values = np.unique(array)
+    if not np.all(np.isin(unique_values, (0.0, 1.0))):
+        raise ValueError(f"{name} must be binary (0 or 1).")
+
+
+def _validate_probabilities(name: str, array: np.ndarray) -> None:
+    """Ensure that an array represents valid probabilities."""
+    if np.any((array < 0.0) | (array > 1.0)):
+        raise ValueError(f"{name} must only contain probabilities in [0, 1].")
+
+
+def _validate_shapes(*arrays: np.ndarray) -> None:
+    """Ensure that all arrays share the same length."""
+    lengths = {array.shape[0] for array in arrays}
+    if len(lengths) != 1:
+        raise ValueError("All inputs must share the same length.")
+
+
+def brier_score(y_true: ArrayLike, y_prob: ArrayLike) -> float:
+    """Compute the Brier score for binary probabilistic predictions."""
+    true = _to_1d_float(y_true)
+    prob = _to_1d_float(y_prob)
+    _validate_shapes(true, prob)
+    _validate_binary("y_true", true)
+    _validate_probabilities("y_prob", prob)
     return float(np.mean((prob - true) ** 2))
 
 
-def expected_calibration_error(y_true: Iterable[int], y_prob: Iterable[float], bins: int = 20) -> float:
-    true = np.asarray(list(y_true), dtype=float)
-    prob = np.asarray(list(y_prob), dtype=float)
-    bin_edges = np.linspace(0.0, 1.0, bins + 1)
+def expected_calibration_error(y_true: ArrayLike, y_prob: ArrayLike, bins: int = 20) -> float:
+    """Compute the Expected Calibration Error (ECE) for probabilistic forecasts."""
+    if bins <= 0:
+        raise ValueError("bins must be a positive integer.")
+    true = _to_1d_float(y_true)
+    prob = _to_1d_float(y_prob)
+    _validate_shapes(true, prob)
+    _validate_binary("y_true", true)
+    _validate_probabilities("y_prob", prob)
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    total = true.shape[0]
     ece = 0.0
-    for lower, upper in zip(bin_edges[:-1], bin_edges[1:]):
-        mask = (prob >= lower) & (prob < upper)
+    for index in range(bins):
+        lower = edges[index]
+        upper = edges[index + 1]
+        if index == bins - 1:
+            mask = (prob >= lower) & (prob <= upper)
+        else:
+            mask = (prob >= lower) & (prob < upper)
         if not np.any(mask):
             continue
         bucket_true = true[mask]
         bucket_prob = prob[mask]
-        acc = bucket_true.mean()
-        conf = bucket_prob.mean()
-        ece += np.abs(acc - conf) * (len(bucket_true) / len(true))
+        accuracy = float(bucket_true.mean())
+        confidence = float(bucket_prob.mean())
+        weight = bucket_true.size / total
+        ece += abs(accuracy - confidence) * weight
     return float(ece)
 
 
 def reliability_bins(
-    y_true: Iterable[int], y_prob: Iterable[float], bins: int = 20
+    y_true: ArrayLike, y_prob: ArrayLike, bins: int = 20
 ) -> tuple[np.ndarray, np.ndarray]:
-    true = np.asarray(list(y_true), dtype=float)
-    prob = np.asarray(list(y_prob), dtype=float)
-    bin_edges = np.linspace(0.0, 1.0, bins + 1)
-    prob_means: list[float] = []
-    acc_means: list[float] = []
-    for lower, upper in zip(bin_edges[:-1], bin_edges[1:]):
-        mask = (prob >= lower) & (prob < upper)
+    """Compute average confidence and accuracy per probability bin."""
+    if bins <= 0:
+        raise ValueError("bins must be a positive integer.")
+    true = _to_1d_float(y_true)
+    prob = _to_1d_float(y_prob)
+    _validate_shapes(true, prob)
+    _validate_binary("y_true", true)
+    _validate_probabilities("y_prob", prob)
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    accuracy: list[float] = []
+    confidence: list[float] = []
+    for index in range(bins):
+        lower = edges[index]
+        upper = edges[index + 1]
+        if index == bins - 1:
+            mask = (prob >= lower) & (prob <= upper)
+        else:
+            mask = (prob >= lower) & (prob < upper)
         if not np.any(mask):
             continue
-        prob_means.append(float(prob[mask].mean()))
-        acc_means.append(float(true[mask].mean()))
-    return np.asarray(prob_means, dtype=float), np.asarray(acc_means, dtype=float)
+        accuracy.append(float(true[mask].mean()))
+        confidence.append(float(prob[mask].mean()))
+    return np.asarray(confidence, dtype=float), np.asarray(accuracy, dtype=float)
 
 
-def roi(y_true: Iterable[int], y_prob: Iterable[float], prices: Iterable[float]) -> float:
-    true = np.asarray(list(y_true), dtype=float)
-    prob = np.asarray(list(y_prob), dtype=float)
-    odds = np.asarray(list(prices), dtype=float)
-    returns = true * (odds - 1) - (1 - true)
-    weights = prob
-    return float(np.sum(returns * weights) / np.sum(np.abs(weights)))
+def roi(y_true: ArrayLike, y_prob: ArrayLike, prices: ArrayLike) -> float:
+    """Compute the weighted average return on investment for a betting strategy."""
+    true = _to_1d_float(y_true)
+    prob = _to_1d_float(y_prob)
+    odds = _to_1d_float(prices)
+    _validate_shapes(true, prob, odds)
+    _validate_binary("y_true", true)
+    _validate_probabilities("y_prob", prob)
+    if np.any(odds <= 0.0):
+        raise ValueError("prices (odds) must be strictly positive.")
+    profits = np.where(true > 0.5, odds - 1.0, -1.0)
+    stakes = np.clip(prob, 0.0, None)
+    total_stake = float(np.sum(stakes))
+    if np.isclose(total_stake, 0.0):
+        return 0.0
+    return float(np.dot(profits, stakes) / total_stake)
 
 
-def bin_counts(probabilities: Iterable[float], bins: int = 20) -> Tuple[np.ndarray, np.ndarray]:
-    probs = np.asarray(list(probabilities), dtype=float)
-    hist, edges = np.histogram(probs, bins=bins, range=(0, 1))
-    return hist, edges
+def bin_counts(probs: ArrayLike, bins: int = 20) -> tuple[np.ndarray, np.ndarray]:
+    """Count probabilities within equally spaced bins across the [0, 1] range."""
+    if bins <= 0:
+        raise ValueError("bins must be a positive integer.")
+    probabilities = _to_1d_float(probs)
+    _validate_probabilities("probs", probabilities)
+    edges = np.linspace(0.0, 1.0, bins + 1)
+    counts, _ = np.histogram(probabilities, bins=edges)
+    return counts.astype(int), edges
 
 
 __all__ = [
     "MetricResult",
+    "bin_counts",
     "brier_score",
     "expected_calibration_error",
-    "roi",
-    "bin_counts",
     "reliability_bins",
+    "roi",
 ]

--- a/tests/test_utils_metrics.py
+++ b/tests/test_utils_metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from ufc_winprob.utils.metrics import (
+    bin_counts,
+    brier_score,
+    expected_calibration_error,
+    roi,
+)
+
+
+def test_brier_score_matches_manual_computation() -> None:
+    y_true = np.array([0, 1, 1, 0])
+    y_prob = np.array([0.1, 0.9, 0.4, 0.2])
+    expected = np.mean((y_prob - y_true) ** 2)
+    score = brier_score(y_true, y_prob)
+    assert_allclose(score, expected)
+    if score < 0.0:
+        pytest.fail("Brier score must be non-negative.")
+
+
+def test_expected_calibration_error_range_and_perfect_case() -> None:
+    y_true = np.array([0, 1, 0, 1])
+    y_prob_perfect = np.array([0.0, 1.0, 0.0, 1.0])
+    assert_allclose(expected_calibration_error(y_true, y_prob_perfect), 0.0)
+    y_prob_imperfect = np.array([0.25, 0.75, 0.25, 0.75])
+    value = expected_calibration_error(y_true, y_prob_imperfect, bins=2)
+    if not (0.0 <= value <= 1.0):
+        pytest.fail("ECE should lie within [0, 1].")
+
+
+def test_roi_weighted_average_returns() -> None:
+    y_true = np.array([1, 0, 1])
+    y_prob = np.array([0.5, 0.2, 0.3])
+    prices = np.array([2.0, 2.0, 2.0])
+    profits = np.array([1.0, -1.0, 1.0])
+    expected = np.average(profits, weights=y_prob)
+    assert_allclose(roi(y_true, y_prob, prices), expected)
+
+
+def test_bin_counts_cover_probability_range() -> None:
+    probs = np.array([0.1, 0.2, 0.35, 0.9])
+    counts, edges = bin_counts(probs, bins=4)
+    if counts.sum() != len(probs):
+        pytest.fail("Counts should match the number of probabilities.")
+    if edges.shape != (5,):
+        pytest.fail("Bin edges should include the endpoints.")
+    assert_allclose(edges[0], 0.0)
+    assert_allclose(edges[-1], 1.0)


### PR DESCRIPTION
## Summary
- implement validation and docstring-rich metric utilities for probability calibration and ROI
- add focused unit tests covering brier score, expected calibration error, ROI, and bin counts

## Testing
- ruff check src/ufc_winprob/utils/metrics.py
- ruff check tests/test_utils_metrics.py
- black src/ufc_winprob/utils/metrics.py tests/test_utils_metrics.py
- mypy . *(fails: missing third-party type stubs such as numpy, pandas, sklearn, fastapi, etc.)*
- pytest -q *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68e59bcf41948320b0f0c71f168129eb