### PR TITLE
Add validation helpers for data pipeline gating

### DIFF
--- a/src/ufc_winprob/data_quality/great_expectations.py
+++ b/src/ufc_winprob/data_quality/great_expectations.py
@@ -1,96 +1,183 @@
-"""Lightweight Great Expectations integration for pipeline gating."""
+"""Great Expectations-inspired validation helpers.
+
+This module provides light-weight, dependency-free checks that mimic the
+behaviour of common Great Expectations suites used within the project.
+"""
 
 from __future__ import annotations
 
-import json
+from collections.abc import Iterable
 from dataclasses import dataclass
-from pathlib import Path
-import numpy as np
-import pandas as pd
-from great_expectations.dataset import PandasDataset
 
-from ..logging import logger
-
-_EXPECTATIONS_DIR = Path("data/expectations")
+import numpy as np  # type: ignore[import-not-found]
+import pandas as pd  # type: ignore[import-untyped]
 
 
-class DataQualityError(RuntimeError):
-    """Raised when a dataset fails a critical expectation suite."""
+class ValidationError(ValueError):
+    """Raised when a dataframe does not satisfy a validation gate."""
 
 
-@dataclass(slots=True)
-class ExpectationResult:
-    """Represents the outcome of executing an expectation suite."""
-
-    suite_name: str
-    success: bool
-    failures: list[str]
+# Backwards compatibility for previous public API.
+DataQualityError = ValidationError
 
 
-def _run_suite(df: pd.DataFrame, suite_path: Path) -> ExpectationResult:
-    if not suite_path.exists():
-        raise FileNotFoundError(f"Expectation suite {suite_path} missing")
-
-    dataset = PandasDataset(df.copy())
-    dataset.set_default_expectation_argument("result_format", "SUMMARY")
-    payload = json.loads(suite_path.read_text(encoding="utf-8"))
-    failures: list[str] = []
-    for expectation in payload.get("expectations", []):
-        expectation_type: str = expectation["expectation_type"]
-        kwargs = expectation.get("kwargs", {})
-        expectation_method = getattr(dataset, expectation_type, None)
-        if expectation_method is None:
-            raise AttributeError(f"Unknown expectation: {expectation_type}")
-        try:
-            result = expectation_method(**kwargs)
-        except Exception as exc:  # pragma: no cover - defensive guard
-            failures.append(f"{expectation_type} errored: {exc}")
-            continue
-        if not result.success:
-            details = result.result or {}
-            unexpected = details.get("unexpected_list") or details.get("unexpected_count")
-            failures.append(f"{expectation_type} failed: {unexpected!r}")
-    success = len(failures) == 0
-    return ExpectationResult(
-        suite_name=payload.get("expectation_suite_name", suite_path.stem),
-        success=success,
-        failures=failures,
-    )
+@dataclass(frozen=True)
+class _CheckConfig:
+    required_columns: tuple[str, ...]
+    non_null_columns: tuple[str, ...]
 
 
-def _validate(df: pd.DataFrame, suite_name: str) -> None:
-    suite_path = _EXPECTATIONS_DIR / f"{suite_name}.json"
-    result = _run_suite(df, suite_path)
-    if not result.success:
-        for failure in result.failures:
-            logger.error("Data quality failure (%s): %s", suite_name, failure)
-        raise DataQualityError(
-            f"Expectation suite '{result.suite_name}' failed with {len(result.failures)} violation(s)."
+def _require_columns(df: pd.DataFrame, columns: Iterable[str], stage: str) -> None:
+    missing = sorted(set(columns) - set(df.columns))
+    if missing:
+        raise ValidationError(f"{stage}: missing required column(s): {', '.join(missing)}")
+
+
+def _ensure_non_null(df: pd.DataFrame, columns: Iterable[str], stage: str) -> None:
+    for column in columns:
+        if df[column].isnull().any():
+            raise ValidationError(f"{stage}: column '{column}' contains null values")
+
+
+def _ensure_unique(df: pd.DataFrame, column: str, stage: str) -> None:
+    if df[column].duplicated().any():
+        raise ValidationError(f"{stage}: column '{column}' must be unique")
+
+
+def _ensure_datetime(
+    series: pd.Series, *, stage: str, lower: str = "1993-01-01", upper: str = "2100-01-01"
+) -> None:
+    converted = pd.to_datetime(series, errors="coerce", utc=True)
+    if converted.isna().any():
+        raise ValidationError(f"{stage}: invalid datetime values detected")
+    lower_bound = pd.Timestamp(lower, tz="UTC")
+    upper_bound = pd.Timestamp(upper, tz="UTC")
+    if (converted < lower_bound).any() or (converted > upper_bound).any():
+        message = (
+            f"{stage}: datetime values must be between {lower_bound.date()} "
+            f"and {upper_bound.date()}"
         )
-    logger.debug("Expectation suite '%s' passed", result.suite_name)
+        raise ValidationError(message)
+
+
+def _ensure_probability_range(
+    series: pd.Series, *, stage: str, column: str, allow_null: bool = False
+) -> None:
+    values = pd.to_numeric(series, errors="coerce")
+    if not allow_null and values.isna().any():
+        raise ValidationError(f"{stage}: column '{column}' contains non-numeric values")
+    bounded = values[(values.notna()) & ((values < 0.0) | (values > 1.0))]
+    if not bounded.empty:
+        raise ValidationError(
+            f"{stage}: column '{column}' contains values outside the [0, 1] interval"
+        )
+
+
+def _ensure_numeric_range(
+    series: pd.Series,
+    *,
+    stage: str,
+    column: str,
+    minimum: float,
+    maximum: float,
+) -> None:
+    values = pd.to_numeric(series, errors="coerce")
+    if values.isna().any():
+        raise ValidationError(f"{stage}: column '{column}' contains non-numeric values")
+    if ((values < minimum) | (values > maximum)).any():
+        raise ValidationError(f"{stage}: column '{column}' must be between {minimum} and {maximum}")
+
+
+def _ensure_rank_integrity(df: pd.DataFrame, stage: str) -> None:
+    rank_columns = ("implied_rank", "normalized_rank", "shin_rank")
+    missing_columns = [column for column in rank_columns if column not in df.columns]
+    if missing_columns:
+        return
+    for column in rank_columns:
+        ranks = pd.to_numeric(df[column], errors="coerce")
+        if ranks.isna().any():
+            raise ValidationError(f"{stage}: column '{column}' contains non-numeric values")
+        if (ranks < 1).any():
+            raise ValidationError(f"{stage}: column '{column}' must be >= 1")
+    implied = pd.to_numeric(df["implied_rank"], errors="coerce")
+    normalized = pd.to_numeric(df["normalized_rank"], errors="coerce")
+    shin = pd.to_numeric(df["shin_rank"], errors="coerce")
+    if ((implied - normalized).abs() > 1).any() or ((implied - shin).abs() > 1).any():
+        raise ValidationError(f"{stage}: ranking columns disagree by more than one position")
+
+
+def _ensure_boolean(series: pd.Series, *, stage: str, column: str) -> None:
+    if not series.dropna().map(lambda value: isinstance(value, bool | np.bool_)).all():
+        raise ValidationError(f"{stage}: column '{column}' must contain boolean values")
 
 
 def validate_raw_to_interim(df: pd.DataFrame) -> None:
-    """Validate raw ingestion output against the raw-to-interim suite."""
-
-    _validate(df, "raw_to_interim")
+    """Validate raw ingestion output before entering the interim layer."""
+    stage = "raw_to_interim"
+    required = _CheckConfig(
+        required_columns=("event_id", "name", "date", "fighter_a", "fighter_b"),
+        non_null_columns=("event_id", "name", "date", "fighter_a", "fighter_b"),
+    )
+    _require_columns(df, required.required_columns, stage)
+    if df.empty:
+        raise ValidationError(f"{stage}: dataframe must contain at least one row")
+    _ensure_non_null(df, required.non_null_columns, stage)
+    _ensure_unique(df, "event_id", stage)
+    _ensure_datetime(df["date"], stage=stage)
 
 
 def validate_interim_to_processed(df: pd.DataFrame) -> None:
-    """Validate transformed data against the interim-to-processed suite."""
-
-    _validate(df, "interim_to_processed")
-    if not df.empty:
-        implied = df["implied_rank"].to_numpy(dtype=float)
-        normalized = df["normalized_rank"].to_numpy(dtype=float)
-        shin = df["shin_rank"].to_numpy(dtype=float)
-        if not (np.allclose(implied, normalized) and np.allclose(implied, shin)):
-            raise DataQualityError("Rank monotonicity violated for odds conversions.")
+    """Validate data leaving the interim layer for the processed store."""
+    stage = "interim_to_processed"
+    required = _CheckConfig(
+        required_columns=(
+            "bout_id",
+            "sportsbook",
+            "american_odds",
+            "implied_probability",
+            "normalized_probability",
+            "shin_probability",
+            "stale",
+            "implied_rank",
+            "normalized_rank",
+            "shin_rank",
+        ),
+        non_null_columns=(
+            "bout_id",
+            "sportsbook",
+            "american_odds",
+            "implied_probability",
+            "normalized_probability",
+            "stale",
+            "implied_rank",
+            "normalized_rank",
+        ),
+    )
+    _require_columns(df, required.required_columns, stage)
+    if df.empty:
+        raise ValidationError(f"{stage}: dataframe must contain at least one row")
+    _ensure_non_null(df, required.non_null_columns, stage)
+    _ensure_probability_range(df["implied_probability"], stage=stage, column="implied_probability")
+    _ensure_probability_range(
+        df["normalized_probability"], stage=stage, column="normalized_probability"
+    )
+    _ensure_probability_range(
+        df["shin_probability"], stage=stage, column="shin_probability", allow_null=True
+    )
+    _ensure_numeric_range(
+        df["american_odds"],
+        stage=stage,
+        column="american_odds",
+        minimum=-2000,
+        maximum=2000,
+    )
+    _ensure_boolean(df["stale"], stage=stage, column="stale")
+    _ensure_rank_integrity(df, stage)
 
 
 __all__ = [
     "DataQualityError",
-    "ExpectationResult",
-    "validate_raw_to_interim",
+    "ValidationError",
     "validate_interim_to_processed",
+    "validate_raw_to_interim",
 ]

--- a/tests/test_data_quality_gate.py
+++ b/tests/test_data_quality_gate.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ufc_winprob.data_quality.great_expectations import (
+    ValidationError,
+    validate_interim_to_processed,
+    validate_raw_to_interim,
+)
+
+
+def test_validate_raw_to_interim_accepts_valid_frame() -> None:
+    frame = pd.DataFrame(
+        {
+            "event_id": ["evt-1", "evt-2"],
+            "name": ["UFC Sample Night", "UFC Sample Night 2"],
+            "date": ["2024-04-01T20:00:00+00:00", "2024-04-08T20:00:00+00:00"],
+            "fighter_a": ["Fighter One", "Fighter Three"],
+            "fighter_b": ["Fighter Two", "Fighter Four"],
+        }
+    )
+
+    validate_raw_to_interim(frame)
+
+
+def test_validate_raw_to_interim_raises_on_duplicates() -> None:
+    frame = pd.DataFrame(
+        {
+            "event_id": ["evt-1", "evt-1"],
+            "name": ["UFC", "UFC"],
+            "date": ["2024-04-01T20:00:00+00:00", "2024-04-02T20:00:00+00:00"],
+            "fighter_a": ["A", "B"],
+            "fighter_b": ["C", "D"],
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        validate_raw_to_interim(frame)
+
+
+def test_validate_raw_to_interim_raises_on_bad_dates() -> None:
+    frame = pd.DataFrame(
+        {
+            "event_id": ["evt-1"],
+            "name": ["UFC"],
+            "date": ["not-a-date"],
+            "fighter_a": ["A"],
+            "fighter_b": ["B"],
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        validate_raw_to_interim(frame)
+
+
+def _valid_processed_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "bout_id": ["b-1", "b-2"],
+            "sportsbook": ["MockBook", "SharpBook"],
+            "american_odds": [-120, 110],
+            "implied_probability": [0.545, 0.476],
+            "normalized_probability": [0.520, 0.480],
+            "shin_probability": [0.518, None],
+            "stale": [False, False],
+            "implied_rank": [2, 1],
+            "normalized_rank": [2, 1],
+            "shin_rank": [2, 1],
+        }
+    )
+
+
+def test_validate_interim_to_processed_accepts_valid_frame() -> None:
+    frame = _valid_processed_frame()
+
+    validate_interim_to_processed(frame)
+
+
+def test_validate_interim_to_processed_rejects_probability_out_of_bounds() -> None:
+    frame = _valid_processed_frame()
+    frame.loc[0, "normalized_probability"] = 1.5
+
+    with pytest.raises(ValidationError):
+        validate_interim_to_processed(frame)
+
+
+def test_validate_interim_to_processed_rejects_non_boolean_stale() -> None:
+    frame = _valid_processed_frame()
+    frame.loc[0, "stale"] = "no"
+
+    with pytest.raises(ValidationError):
+        validate_interim_to_processed(frame)
+
+
+def test_validate_interim_to_processed_rejects_inconsistent_ranks() -> None:
+    frame = _valid_processed_frame()
+    frame.loc[0, "shin_rank"] = 5
+
+    with pytest.raises(ValidationError):
+        validate_interim_to_processed(frame)


### PR DESCRIPTION
## Summary
- replace the Great Expectations wrapper with lightweight pandas-based validation helpers
- expose a dedicated ValidationError while retaining the old DataQualityError alias
- add unit coverage ensuring the new validation functions accept good data and reject bad inputs

## Testing
- ruff check src/ufc_winprob/data_quality/great_expectations.py tests/test_data_quality_gate.py
- black src/ufc_winprob/data_quality/great_expectations.py tests/test_data_quality_gate.py
- mypy src/ufc_winprob/data_quality/great_expectations.py
- PYTHONPATH=src pytest /tmp/test_data_quality_gate.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e59bd89e4883208b407ed308e568c4