### PR TITLE
Implement predict endpoint and add API tests

### DIFF
--- a/src/ufc_winprob/api/routers/predict.py
+++ b/src/ufc_winprob/api/routers/predict.py
@@ -3,55 +3,69 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
-import pandas as pd
 from fastapi import APIRouter, HTTPException
 
 from ufc_winprob.api.schemas import PredictionResponse, PredictRequest
-from ufc_winprob.features.age_curve import age_curve_effect
-from ufc_winprob.models.calibration import Calibrator
-from ufc_winprob.models.persistence import MODEL_DIR, load_artifact
-from ufc_winprob.utils.odds_utils import american_to_implied
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers
+    import pandas as pd
+
+    from ufc_winprob.models.calibration import Calibrator
 
 router = APIRouter(tags=["probabilities"])
 
-_DEFAULT_RATING = 1500.0
-_DEFAULT_HEIGHT = 72.0
-_DEFAULT_REACH = 72.0
-_DEFAULT_AGE = 30.0
-_DEFAULT_ACTIVITY_GAP = 60.0
 _DEFAULT_DIVISION = "LW"
+_DEFAULT_RATING = 1500.0
+_DEFAULT_AGE = 30.0
+_DEFAULT_HEIGHT = 70.0
+_DEFAULT_REACH = 70.0
+_DEFAULT_ACTIVITY_GAP = 60.0
+_DEFAULT_SCHEDULED_ROUNDS = 3.0
+_CONFIDENCE_DELTA = 0.05
 
 
-def _neutral_feature_vector(feature_names: Iterable[str]) -> dict[str, float]:
-    """Return a neutral feature dictionary compatible with the trained model."""
+def _validate_payload(payload: PredictRequest) -> None:
+    """Ensure numeric payload fields are positive when provided."""
+    numeric_fields = (
+        "fighter_age",
+        "opponent_age",
+        "fighter_height",
+        "opponent_height",
+        "fighter_reach",
+        "opponent_reach",
+    )
+    for field in numeric_fields:
+        value = getattr(payload, field)
+        if value is not None and value <= 0:
+            raise HTTPException(status_code=422, detail=f"{field} must be positive")
+
+
+def _neutral_features(feature_names: Iterable[str], market_probability: float) -> dict[str, float]:
+    """Return neutral defaults compatible with the trained model."""
     features: dict[str, float] = {}
     for name in feature_names:
         if name.startswith("fighter_") or name.startswith("opponent_"):
             features[name] = _DEFAULT_RATING
+        elif name == "market_prob":
+            features[name] = market_probability
         elif name == "scheduled_rounds":
-            features[name] = 3.0
-        elif name == "is_main_event":
-            features[name] = 0.0
+            features[name] = _DEFAULT_SCHEDULED_ROUNDS
         elif name == "activity_gap":
             features[name] = _DEFAULT_ACTIVITY_GAP
-        elif name == "market_prob":
-            features[name] = 0.5
-        elif name.endswith("_diff"):
-            features[name] = 0.0
         else:
             features[name] = 0.0
     return features
 
 
-def _apply_metric_features(
+def _set_pair_features(
     features: dict[str, float],
+    prefix: str,
     fighter_value: float,
     opponent_value: float,
-    prefix: str,
 ) -> None:
-    """Populate mirrored features and their difference when available."""
+    """Populate mirrored and differential features when available."""
     primary = f"{prefix}_a"
     secondary = f"{prefix}_b"
     diff_name = f"{prefix}_diff"
@@ -63,14 +77,23 @@ def _apply_metric_features(
         features[diff_name] = fighter_value - opponent_value
 
 
+def _set_single_feature(features: dict[str, float], name: str, value: float) -> None:
+    if name in features:
+        features[name] = value
+
+
 def _build_feature_frame(
     payload: PredictRequest,
-    feature_index: pd.Index,
+    feature_names: Iterable[str],
     market_probability: float,
     division: str,
 ) -> pd.DataFrame:
     """Construct the single-row feature frame expected by the classifier."""
-    features = _neutral_feature_vector(feature_index)
+    import numpy as np
+    import pandas as pd
+
+    from ufc_winprob.features.age_curve import age_curve_effect
+
     fighter_age = float(payload.fighter_age or _DEFAULT_AGE)
     opponent_age = float(payload.opponent_age or _DEFAULT_AGE)
     fighter_height = float(payload.fighter_height or _DEFAULT_HEIGHT)
@@ -78,56 +101,64 @@ def _build_feature_frame(
     fighter_reach = float(payload.fighter_reach or _DEFAULT_REACH)
     opponent_reach = float(payload.opponent_reach or _DEFAULT_REACH)
 
-    _apply_metric_features(features, fighter_age, opponent_age, "age")
-    _apply_metric_features(features, fighter_height, opponent_height, "height")
-    _apply_metric_features(features, fighter_reach, opponent_reach, "reach")
+    features = _neutral_features(feature_names, market_probability)
 
-    age_effect_a = age_curve_effect(fighter_age, division)
-    age_effect_b = age_curve_effect(opponent_age, division)
-    if "age_effect_a" in features:
-        features["age_effect_a"] = age_effect_a
-    if "age_effect_b" in features:
-        features["age_effect_b"] = age_effect_b
-    if "age_effect_diff" in features:
-        features["age_effect_diff"] = age_effect_a - age_effect_b
+    _set_pair_features(features, "age", fighter_age, opponent_age)
+    _set_pair_features(features, "height", fighter_height, opponent_height)
+    _set_pair_features(features, "reach", fighter_reach, opponent_reach)
 
-    if "market_prob" in features:
-        features["market_prob"] = market_probability
+    age_effect_fighter = float(age_curve_effect(fighter_age, division=division))
+    age_effect_opponent = float(age_curve_effect(opponent_age, division=division))
+    _set_pair_features(features, "age_effect", age_effect_fighter, age_effect_opponent)
 
-    frame = pd.DataFrame([features], columns=feature_index)
+    _set_single_feature(features, "fighter_age", fighter_age)
+    _set_single_feature(features, "opponent_age", opponent_age)
+    _set_single_feature(features, "fighter_height", fighter_height)
+    _set_single_feature(features, "opponent_height", opponent_height)
+    _set_single_feature(features, "fighter_reach", fighter_reach)
+    _set_single_feature(features, "opponent_reach", opponent_reach)
+
+    columns = list(feature_names)
+    frame = pd.DataFrame([[features[name] for name in columns]], columns=columns)
     return frame.astype(np.float64, copy=False)
 
 
-def _load_model_artifacts() -> tuple[object, Calibrator]:
+def _load_model_artifacts() -> tuple[Any, Calibrator]:
+    """Load classifier and calibrator artifacts from disk."""
+    from ufc_winprob.models.calibration import Calibrator
+    from ufc_winprob.models.persistence import MODEL_DIR, load_artifact
+
     try:
-        classifier = load_artifact("classifier.joblib")
+        classifier: Any = load_artifact("classifier.joblib")
         calibrator = Calibrator.load(MODEL_DIR / "calibrator.joblib")
-    except FileNotFoundError as exc:  # pragma: no cover - validated in tests
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
         raise HTTPException(status_code=503, detail="Model artifacts unavailable") from exc
     return classifier, calibrator
 
 
 @router.post("/predict", response_model=PredictionResponse)
-def predict_single(payload: PredictRequest) -> PredictionResponse:
+def predict(payload: PredictRequest) -> PredictionResponse:
     """Generate a win probability for the requested fighter."""
+    _validate_payload(payload)
+
     american_odds = payload.american_odds
     market_probability: float | None = None
     if american_odds is not None:
+        from ufc_winprob.utils.odds_utils import american_to_implied
+
         try:
-            market_probability = american_to_implied(american_odds)
+            market_probability = float(american_to_implied(american_odds))
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     classifier, calibrator = _load_model_artifacts()
-
     feature_names = getattr(classifier, "feature_names_in_", None)
     if feature_names is None:
         raise HTTPException(status_code=500, detail="Model missing feature metadata")
 
     division = (payload.division or calibrator.default_division or _DEFAULT_DIVISION).upper()
-    base_prob = market_probability if market_probability is not None else 0.5
-    feature_index = pd.Index(feature_names)
-    frame = _build_feature_frame(payload, feature_index, base_prob, division)
+    base_market_probability = market_probability if market_probability is not None else 0.5
+    frame = _build_feature_frame(payload, feature_names, base_market_probability, division)
 
     try:
         probabilities = classifier.predict_proba(frame)
@@ -136,8 +167,8 @@ def predict_single(payload: PredictRequest) -> PredictionResponse:
 
     raw_probability = float(probabilities[0, 1])
     calibrated = float(calibrator.transform([raw_probability], [division])[0])
-    probability_low = float(np.clip(calibrated - 0.05, 0.0, 1.0))
-    probability_high = float(np.clip(calibrated + 0.05, 0.0, 1.0))
+    probability_low = max(0.0, calibrated - _CONFIDENCE_DELTA)
+    probability_high = min(1.0, calibrated + _CONFIDENCE_DELTA)
 
     return PredictionResponse(
         bout_id=payload.bout_id,
@@ -149,4 +180,4 @@ def predict_single(payload: PredictRequest) -> PredictionResponse:
     )
 
 
-__all__ = ["router"]
+__all__ = ["PredictRequest", "PredictionResponse", "router"]

--- a/tests/test_api_predict.py
+++ b/tests/test_api_predict.py
@@ -1,0 +1,55 @@
+"""Tests for the /predict API endpoint."""
+
+from __future__ import annotations
+
+# ruff: noqa: S101
+from collections.abc import Mapping
+
+from fastapi.testclient import TestClient
+
+from ufc_winprob.api.main import create_app
+from ufc_winprob.api.schemas import PredictionResponse
+
+
+def test_predict_returns_prediction(trained_model: Mapping[str, object]) -> None:
+    assert "model" in trained_model
+    app = create_app()
+    client = TestClient(app)
+    payload = {
+        "bout_id": "evt-1-main",
+        "fighter": "Fighter A",
+        "opponent": "Fighter B",
+        "division": "LW",
+        "american_odds": -150,
+        "fighter_age": 32,
+        "opponent_age": 30,
+        "fighter_height": 72,
+        "opponent_height": 70,
+        "fighter_reach": 74,
+        "opponent_reach": 72,
+    }
+
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    validated = PredictionResponse.model_validate(body)
+    assert validated.bout_id == payload["bout_id"]
+    assert validated.fighter == payload["fighter"]
+    assert 0.0 <= validated.probability <= 1.0
+    assert validated.probability_low <= validated.probability <= validated.probability_high
+    assert validated.market_probability is not None
+
+
+def test_predict_rejects_negative_values(trained_model: Mapping[str, object]) -> None:
+    assert "model" in trained_model
+    app = create_app()
+    client = TestClient(app)
+    payload = {
+        "bout_id": "evt-1-main",
+        "fighter": "Fighter A",
+        "opponent": "Fighter B",
+        "fighter_age": -5,
+    }
+
+    response = client.post("/predict", json=payload)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- implement the `/predict` API route with request validation, default feature handling, and calibrated probability bounds
- load the persisted model and calibrator lazily and convert american odds to implied probability when provided
- add focused API tests covering a successful prediction response and validation failure cases

## Testing
- `pytest tests/test_api_predict.py -q`
- `ruff check src/ufc_winprob/api/routers/predict.py tests/test_api_predict.py`
- `black src/ufc_winprob/api/routers/predict.py tests/test_api_predict.py`


------
https://chatgpt.com/codex/tasks/task_e_68e59b9bb1188320bc39824af73a4adf