### PR TITLE
Ensure markets endpoint schema stability

### DIFF
--- a/src/ufc_winprob/api/routers/markets.py
+++ b/src/ufc_winprob/api/routers/markets.py
@@ -1,7 +1,9 @@
-"""Markets router exposing odds snapshots."""
+"""Markets router exposing odds snapshots with a stable schema."""
 
 from __future__ import annotations
 
+import math
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -15,71 +17,172 @@ router = APIRouter(prefix="/markets", tags=["markets"])
 _DATA_PATH = Path("data/processed/market_odds.parquet")
 
 
-def _ensure_columns(frame: pd.DataFrame) -> pd.DataFrame:
-    """Ensure the DataFrame contains the columns required by the API schema."""
-    working = frame.copy()
-    if "timestamp" not in working.columns:
-        working["timestamp"] = datetime.now(UTC)
-    working["timestamp"] = pd.to_datetime(working["timestamp"], utc=True)
+def _american_odds_to_probability(odds: float) -> float:
+    """Convert American odds into a probability."""
+    if odds >= 0:
+        return 100.0 / (odds + 100.0)
+    return -odds / (-odds + 100.0)
 
-    if "american_odds" not in working.columns:
-        working["american_odds"] = 0.0
-    if "implied_probability" not in working.columns:
-        working["implied_probability"] = 0.5
-    if "normalized_probability" not in working.columns:
-        working["normalized_probability"] = working["implied_probability"].astype(float)
-    if "overround" not in working.columns:
-        working["overround"] = 0.0
-    if "z_shin" not in working.columns:
-        working["z_shin"] = 0.0
-    if "stale" not in working.columns:
-        working["stale"] = False
-    if "book" not in working.columns:
-        working["book"] = working.get("sportsbook", "Unknown")
-    if "sportsbook" not in working.columns:
-        working["sportsbook"] = working["book"]
-    return working
+
+def _synthetic_frame() -> pd.DataFrame:
+    """Generate a small synthetic odds snapshot with two sportsbooks."""
+    now = datetime.now(UTC)
+    synthetic_rows = [
+        {
+            "bout_id": "synthetic-bout",
+            "sportsbook": "ExampleBookA",
+            "book": "ExampleBookA",
+            "price": -110.0,
+            "implied_probability": _american_odds_to_probability(-110.0),
+            "normalized_probability": _american_odds_to_probability(-110.0),
+            "overround": 0.02,
+            "z_shin": 0.0,
+            "stale": False,
+            "last_updated": now,
+        },
+        {
+            "bout_id": "synthetic-bout",
+            "sportsbook": "ExampleBookB",
+            "book": "ExampleBookB",
+            "price": 105.0,
+            "implied_probability": _american_odds_to_probability(105.0),
+            "normalized_probability": _american_odds_to_probability(105.0),
+            "overround": 0.02,
+            "z_shin": 0.0,
+            "stale": False,
+            "last_updated": now,
+        },
+    ]
+    return pd.DataFrame(synthetic_rows)
+
+
+def _load_market_frame(path: Path) -> pd.DataFrame:
+    """Load the market snapshot from disk or fall back to synthetic data."""
+    if path.exists():
+        try:
+            frame = pd.read_parquet(path)
+        except Exception:
+            frame = pd.DataFrame()
+        if not frame.empty:
+            return frame
+    return _synthetic_frame()
+
+
+def _coerce_float(value: object, default: float) -> float:
+    """Safely coerce any value to a float with a default."""
+    if value is None:
+        return default
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isnan(result):
+        return default
+    return result
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    """Safely coerce any value to a boolean with a default."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "t", "1", "yes"}:
+            return True
+        if lowered in {"false", "f", "0", "no"}:
+            return False
+        return default
+    if isinstance(value, int | float):
+        return bool(value)
+    return default
+
+
+def _coerce_str(value: object, default: str) -> str:
+    """Safely coerce any value to a string with a default."""
+    if value is None:
+        return default
+    text = str(value)
+    return text if text else default
+
+
+def _coerce_datetime(value: object, default: datetime) -> datetime:
+    """Safely coerce any value to an aware UTC datetime."""
+    candidate: datetime | None
+    if value is None:
+        candidate = None
+    elif isinstance(value, datetime):
+        candidate = value
+    elif isinstance(value, pd.Timestamp):
+        candidate = value.to_pydatetime()
+    else:
+        try:
+            converted = pd.to_datetime(value, utc=True)
+        except (TypeError, ValueError):
+            candidate = None
+        else:
+            if isinstance(converted, pd.Timestamp):
+                candidate = converted.to_pydatetime()
+            elif isinstance(converted, datetime):
+                candidate = converted
+            else:
+                candidate = None
+    if candidate is None:
+        candidate = default
+    if candidate.tzinfo is None:
+        return candidate.replace(tzinfo=UTC)
+    return candidate.astimezone(UTC)
+
+
+def _iter_market_records(frame: pd.DataFrame) -> Iterable[MarketResponse]:
+    """Yield MarketResponse objects from a raw dataframe."""
+    records = frame.to_dict(orient="records")
+    for raw in records:
+        fallback_timestamp = datetime.now(UTC)
+        timestamp_source = raw.get("last_updated")
+        if timestamp_source is None:
+            timestamp_source = raw.get("timestamp")
+        last_updated = _coerce_datetime(timestamp_source, fallback_timestamp)
+
+        sportsbook = _coerce_str(raw.get("sportsbook"), "Unknown")
+        book = _coerce_str(raw.get("book"), sportsbook)
+
+        price_source = raw.get("price")
+        if price_source is None:
+            price_source = raw.get("american_odds")
+        price = _coerce_float(price_source, 0.0)
+
+        implied_probability = _coerce_float(
+            raw.get("implied_probability"),
+            _american_odds_to_probability(price),
+        )
+        normalized_probability = _coerce_float(
+            raw.get("normalized_probability"),
+            implied_probability,
+        )
+        overround = _coerce_float(raw.get("overround"), 0.0)
+        z_shin = _coerce_float(raw.get("z_shin"), 0.0)
+        stale = _coerce_bool(raw.get("stale"), False)
+        bout_id = _coerce_str(raw.get("bout_id"), "unknown-bout")
+
+        yield MarketResponse(
+            bout_id=bout_id,
+            book=book,
+            sportsbook=sportsbook,
+            price=price,
+            implied_probability=implied_probability,
+            normalized_probability=normalized_probability,
+            overround=overround,
+            last_updated=last_updated,
+            z_shin=z_shin,
+            stale=stale,
+        )
 
 
 @router.get("/", response_model=list[MarketResponse])
 def markets() -> list[MarketResponse]:
     """Return the latest market snapshot for each recorded bout."""
-    if not _DATA_PATH.exists():
-        return []
-
-    frame = pd.read_parquet(_DATA_PATH)
-    if frame.empty:
-        return []
-
-    normalized = _ensure_columns(frame)
-    responses: list[MarketResponse] = []
-    for row in normalized.itertuples(index=False):
-        timestamp = row.timestamp
-        if isinstance(timestamp, str):
-            ts = datetime.fromisoformat(timestamp)
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=UTC)
-        else:
-            ts = timestamp.to_pydatetime() if hasattr(timestamp, "to_pydatetime") else timestamp
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=UTC)
-            else:
-                ts = ts.astimezone(UTC)
-
-        responses.append(
-            MarketResponse(
-                bout_id=str(getattr(row, "bout_id", "")),
-                book=str(getattr(row, "book", getattr(row, "sportsbook", "Unknown"))),
-                sportsbook=str(getattr(row, "sportsbook", getattr(row, "book", "Unknown"))),
-                price=float(getattr(row, "american_odds", 0.0)),
-                implied_probability=float(getattr(row, "implied_probability", 0.5)),
-                normalized_probability=float(getattr(row, "normalized_probability", 0.5)),
-                overround=float(getattr(row, "overround", 0.0)),
-                last_updated=ts,
-                z_shin=float(getattr(row, "z_shin", 0.0)),
-                stale=bool(getattr(row, "stale", False)),
-            )
-        )
+    frame = _load_market_frame(_DATA_PATH)
+    responses = list(_iter_market_records(frame))
     return responses
 
 

--- a/tests/test_api_markets.py
+++ b/tests/test_api_markets.py
@@ -1,0 +1,56 @@
+"""Tests for the /markets endpoint schema stability."""
+
+from __future__ import annotations
+
+# ruff: noqa: S101
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ufc_winprob.api.main import create_app
+from ufc_winprob.api.routers import markets as markets_router
+from ufc_winprob.api.schemas import MarketResponse
+
+
+def _assert_field_types(entry: dict[str, Any]) -> None:
+    assert isinstance(entry["bout_id"], str)
+    assert isinstance(entry["book"], str)
+    assert isinstance(entry["sportsbook"], str)
+    assert isinstance(entry["price"], float)
+    assert isinstance(entry["implied_probability"], float)
+    assert isinstance(entry["normalized_probability"], float)
+    assert isinstance(entry["overround"], float)
+    assert isinstance(entry["z_shin"], float)
+    assert isinstance(entry["stale"], bool)
+
+    last_updated = entry["last_updated"]
+    assert isinstance(last_updated, str)
+    parsed = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.astimezone(UTC).tzinfo == UTC
+
+
+def test_markets_endpoint_returns_complete_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """/markets returns a non-empty list containing all required fields."""
+    synthetic_path = tmp_path / "nonexistent.parquet"
+    monkeypatch.setattr(markets_router, "_DATA_PATH", synthetic_path)
+
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.get("/markets/")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert payload
+
+    entry = payload[0]
+    required_keys = set(MarketResponse.model_fields)
+    assert required_keys.issubset(entry.keys())
+    _assert_field_types(entry)


### PR DESCRIPTION
## Summary
- update the markets router to read the odds snapshot when available and fall back to a synthetic two-book example while coercing defaults for missing fields
- ensure every MarketResponse includes all schema fields with timezone-aware timestamps and strong validation helpers
- add an API test that exercises /markets and verifies the response shape and types

## Testing
- `ruff check src/ufc_winprob/api/routers/markets.py tests/test_api_markets.py`
- `black src/ufc_winprob/api/routers/markets.py tests/test_api_markets.py`
- `mypy src` *(fails: missing third-party type stubs such as pandas, numpy, fastapi, etc.)*
- `pytest -q tests/test_api_markets.py` *(fails: missing runtime dependency pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68e59ba8d6e0832090492c39d935d26d