### PR TITLE
Add API metrics middleware and system endpoints

### DIFF
--- a/src/ufc_winprob/api/main.py
+++ b/src/ufc_winprob/api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from time import perf_counter
@@ -12,10 +13,30 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from ufc_winprob.api.routers import fights, markets, predict, probabilities, recommendations
-from ufc_winprob.api.schemas import HealthResponse
 from ufc_winprob.logging import configure_logging
-from ufc_winprob.observability import API_EXCEPTIONS, API_LATENCY, API_REQUESTS
 from ufc_winprob.settings import get_settings
+
+try:
+    from ufc_winprob.observability import API_EXCEPTIONS, API_LATENCY, API_REQUESTS
+except ImportError:  # pragma: no cover - fallback for stripped deployments
+    from prometheus_client import Counter, Histogram
+
+    API_REQUESTS = Counter(
+        "ufc_api_requests_total",
+        "Total API requests processed by route, method, and status code.",
+        labelnames=("route", "method", "status"),
+    )
+    API_LATENCY = Histogram(
+        "ufc_api_request_latency_seconds",
+        "Latency of API requests in seconds.",
+        labelnames=("route", "method"),
+    )
+    API_EXCEPTIONS = Counter(
+        "ufc_api_exceptions_total",
+        "Exceptions raised while serving API routes.",
+        labelnames=("route", "method"),
+    )
+
 
 RequestHandler = Callable[[Request], Awaitable[Response]]
 
@@ -50,15 +71,20 @@ def create_app() -> FastAPI:
     app = FastAPI(title=settings.project_name)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=[
+            "http://localhost",
+            "http://localhost:3000",
+            "http://127.0.0.1",
+            "http://127.0.0.1:3000",
+        ],
         allow_methods=["*"],
         allow_headers=["*"],
     )
     app.add_middleware(PrometheusRequestMiddleware)
 
-    @app.get("/health", response_model=HealthResponse, tags=["system"])
-    def health() -> HealthResponse:
-        return HealthResponse(status="ok", timestamp=datetime.now(UTC))
+    @app.get("/health", tags=["system"])
+    def health() -> dict[str, str]:
+        return {"status": "ok", "time": datetime.now(UTC).isoformat()}
 
     @app.get("/metrics", tags=["system"])
     def metrics() -> Response:
@@ -66,10 +92,10 @@ def create_app() -> FastAPI:
         return Response(payload, media_type=CONTENT_TYPE_LATEST)
 
     app.include_router(fights.router)
-    app.include_router(probabilities.router)
-    app.include_router(predict.router)
     app.include_router(markets.router)
+    app.include_router(probabilities.router)
     app.include_router(recommendations.router)
+    app.include_router(predict.router)
 
     return app
 
@@ -79,7 +105,15 @@ def main() -> None:
     import uvicorn
 
     app = create_app()
-    uvicorn.run(app, host="0.0.0.0", port=8000)  # noqa: S104
+    settings = get_settings()
+
+    port_str = os.getenv("PORT") or os.getenv("APP_PORT") or str(getattr(settings, "api_port", ""))
+    try:
+        port = int(port_str)
+    except (TypeError, ValueError):
+        port = 8000
+
+    uvicorn.run(app, host="0.0.0.0", port=port)  # noqa: S104
 
 
 if __name__ == "__main__":

--- a/tests/test_api_main.py
+++ b/tests/test_api_main.py
@@ -1,0 +1,40 @@
+# ruff: noqa: S101
+"""Tests for the FastAPI application entrypoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from ufc_winprob.api.main import create_app
+
+
+def get_test_client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+def test_health_endpoint_returns_status_and_time() -> None:
+    client = get_test_client()
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload.keys()) == {"status", "time"}
+    assert payload["status"] == "ok"
+    assert isinstance(payload["time"], str) and payload["time"]
+
+
+def test_metrics_endpoint_exposes_api_metrics() -> None:
+    client = get_test_client()
+
+    # Trigger at least one request so counters are initialised.
+    client.get("/health")
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "ufc_api_requests_total" in body
+    assert "ufc_api_request_latency_seconds" in body
+    assert "ufc_api_exceptions_total" in body


### PR DESCRIPTION
## Summary
- add Prometheus-powered request metrics middleware and system routes to the FastAPI app
- configure localhost CORS and include the upcoming fights, markets, probabilities, recommendations, and prediction routers
- add tests covering the health and metrics endpoints

## Testing
- ruff check src/ufc_winprob/api/main.py tests/test_api_main.py
- black src/ufc_winprob/api/main.py tests/test_api_main.py
- mypy src/ufc_winprob/api/main.py tests/test_api_main.py *(fails: missing third-party type stubs and imports such as numpy, fastapi, prometheus_client, etc.)*
- pytest -q *(fails: ImportError for optional dependency pandas when loading test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e59bb069948320bbee662ece64d33f