### PR TITLE
Implement configurable scheduler and tests

### DIFF
--- a/src/ufc_winprob/jobs/scheduler.py
+++ b/src/ufc_winprob/jobs/scheduler.py
@@ -3,41 +3,90 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
+from collections.abc import Callable
 
+from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED, JobExecutionEvent
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
 from loguru import logger
 
-from ..pipelines.daily_refresh import daily_refresh
-from ..settings import get_settings
+from ufc_winprob.pipelines.daily_refresh import daily_refresh
+from ufc_winprob.settings import get_settings
+
+
+def _build_daily_refresh_job(use_live_odds: bool) -> Callable[[], None]:
+    """Create the callable used by APScheduler for the daily refresh job."""
+
+    def _job() -> None:
+        try:
+            daily_refresh(use_live_odds=use_live_odds)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            logger.exception("daily_refresh job failed: %s", exc)
+            raise
+
+    return _job
+
+
+def _log_job_event(scheduler: BlockingScheduler, event: JobExecutionEvent) -> None:
+    """Log a concise summary for each job execution event."""
+    job = scheduler.get_job(event.job_id)
+    next_run = job.next_run_time.isoformat() if job and job.next_run_time else "unscheduled"
+    if event.exception:
+        logger.error(
+            "Job {} failed at {} (next_run={})",
+            event.job_id,
+            event.scheduled_run_time,
+            next_run,
+        )
+    else:
+        logger.info(
+            "Job {} succeeded at {} (next_run={})",
+            event.job_id,
+            event.scheduled_run_time,
+            next_run,
+        )
 
 
 def start_scheduler() -> None:
+    """Initialise and start the APScheduler blocking scheduler."""
     settings = get_settings()
     timezone_name = os.environ.get("TZ") or settings.tz
     scheduler = BlockingScheduler(timezone=timezone_name)
-    cron = settings.jobs.daily_refresh_cron
-    trigger = CronTrigger.from_crontab(cron, timezone=scheduler.timezone)
-    scheduler.add_job(
-        lambda: daily_refresh(use_live_odds=settings.use_live_odds),
+
+    cron_expression = settings.jobs.daily_refresh_cron
+    trigger = CronTrigger.from_crontab(cron_expression, timezone=scheduler.timezone)
+
+    job = scheduler.add_job(
+        _build_daily_refresh_job(settings.use_live_odds),
         trigger=trigger,
         id="daily_refresh",
         replace_existing=True,
     )
-    next_run = trigger.get_next_fire_time(None, datetime.now(scheduler.timezone))
-    logger.info(
-        "Scheduler initialised (timezone=%s, cron=%s, next_run=%s)",
-        timezone_name,
-        cron,
-        next_run,
+
+    if job.next_run_time:
+        logger.info(
+            "daily_refresh scheduled (cron={}, timezone={}, next_run={})",
+            cron_expression,
+            scheduler.timezone,
+            job.next_run_time.isoformat(),
+        )
+    else:  # pragma: no cover - defensive logging path
+        logger.warning(
+            "daily_refresh scheduled without a computed next run (cron={}, timezone={})",
+            cron_expression,
+            scheduler.timezone,
+        )
+
+    scheduler.add_listener(
+        lambda event: _log_job_event(scheduler, event),
+        EVENT_JOB_EXECUTED | EVENT_JOB_ERROR,
     )
-    for job in scheduler.get_jobs():
-        logger.info("Scheduled job %s -> %s", job.id, job.next_run_time)
+
     scheduler.start()
 
 
 def main() -> None:
+    """Entry point used by console scripts."""
     start_scheduler()
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from types import ModuleType
+from typing import ClassVar
+from zoneinfo import ZoneInfo
+
+import pytest
+from apscheduler.triggers.cron import CronTrigger
+
+
+@dataclass
+class DummyJob:
+    scheduler: DummyScheduler
+    job_id: str
+    trigger: CronTrigger
+    func: Callable[[], None]
+    next_run_time: datetime = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Compute the next run time when the job is created."""
+        self.next_run_time = self.trigger.get_next_fire_time(
+            None,
+            datetime.now(self.scheduler.timezone),
+        )
+
+
+class DummyScheduler:
+    instances: ClassVar[list[DummyScheduler]] = []
+
+    def __init__(self, timezone: str | ZoneInfo) -> None:
+        """Initialise the dummy scheduler with the provided timezone."""
+        self.timezone = ZoneInfo(timezone) if isinstance(timezone, str) else timezone
+        self.jobs: dict[str, DummyJob] = {}
+        self.listeners: list[tuple[Callable[[object], None], int]] = []
+        self.started = False
+        DummyScheduler.instances.append(self)
+
+    def add_job(
+        self,
+        func: Callable[[], None],
+        trigger: CronTrigger,
+        *,
+        replace_existing: bool = False,
+        **kwargs: object,
+    ) -> DummyJob:
+        job_id = str(kwargs["id"])
+        if replace_existing and job_id in self.jobs:
+            del self.jobs[job_id]
+        job = DummyJob(self, job_id, trigger, func)
+        self.jobs[job_id] = job
+        return job
+
+    def add_listener(self, callback: Callable[[object], None], mask: int) -> None:
+        self.listeners.append((callback, mask))
+
+    def get_job(self, job_id: str) -> DummyJob | None:
+        return self.jobs.get(job_id)
+
+    def start(self) -> None:
+        self.started = True
+
+
+class FakeJobsConfig:
+    daily_refresh_cron = "15 10 * * *"
+
+
+class FakeSettings:
+    jobs = FakeJobsConfig()
+    tz = "America/Los_Angeles"
+    use_live_odds = True
+
+
+@pytest.fixture(autouse=True)
+def clear_dummy_instances() -> None:
+    DummyScheduler.instances.clear()
+
+
+def test_scheduler_uses_cron_and_timezone(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    stub_daily_refresh = ModuleType("ufc_winprob.pipelines.daily_refresh")
+    stub_daily_refresh.daily_refresh = lambda **_: None
+    monkeypatch.setitem(sys.modules, "ufc_winprob.pipelines.daily_refresh", stub_daily_refresh)
+    sys.modules.pop("ufc_winprob.jobs.scheduler", None)
+    scheduler_module = importlib.import_module("ufc_winprob.jobs.scheduler")
+
+    monkeypatch.setenv("TZ", "Europe/Paris")
+    monkeypatch.setattr(scheduler_module, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(scheduler_module, "BlockingScheduler", DummyScheduler)
+    scheduler_module.logger.add(caplog.handler, level="INFO")
+
+    caplog.set_level("INFO")
+    scheduler_module.start_scheduler()
+
+    scheduler_instance = DummyScheduler.instances[-1]
+    job = scheduler_instance.get_job("daily_refresh")
+    if job is None:
+        pytest.fail("daily_refresh job was not registered")
+
+    tz = scheduler_instance.timezone
+    reference = datetime(2024, 1, 1, 9, 0, tzinfo=tz)
+    next_run = job.trigger.get_next_fire_time(None, reference)
+    expected = datetime(2024, 1, 1, 10, 15, tzinfo=tz)
+    if next_run != expected:
+        pytest.fail(f"Unexpected next run time: {next_run!r}")
+
+    next_run_str = job.next_run_time.isoformat()
+    if next_run_str not in caplog.text:
+        pytest.fail("Next run time was not logged on scheduler startup")
+
+    if not scheduler_instance.started:
+        pytest.fail("Scheduler.start was not invoked")


### PR DESCRIPTION
## Summary
- update the APScheduler setup to honour configured cron expressions, timezone environment overrides, and to log initial and per-run status details with error handling
- add a scheduler unit test that patches the blocking scheduler, validates cron parsing/timezone usage, and checks logging of the next run time

## Testing
- pytest tests/test_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68e59bbaf32c8320a13a732cecede6cd